### PR TITLE
Use new more conservative handlers to only patch missing features

### DIFF
--- a/handlers/image-handler.js
+++ b/handlers/image-handler.js
@@ -1,6 +1,7 @@
 class ImageHandler {
-  constructor () {
+  constructor (supportsWebP) {
     this.customElement = 'lazyload-image'
+    this.supportsWebP = supportsWebP
   }
 
   element (element) {
@@ -12,7 +13,7 @@ class ImageHandler {
         element.removeAttribute('src')
       }
     } else if (!element.hasAttribute('is')) {
-      if (element.getAttribute('src').endsWith('.webp')) {
+      if (element.getAttribute('src').endsWith('.webp') && !this.supportsWebP) {
         element.setAttribute('is', 'webp-support')
       }
     }

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ async function handleRequest(request) {
 
   const supportsLazyLoadIframe = browser.satisfies({
     chrome: '>85',
-    firefox: '>82'
+    firefox: '>84'
   })
 
   if (!supportsLazyLoadIframe) {
@@ -31,6 +31,7 @@ async function handleRequest(request) {
         chrome: '>32',
         firefox: '>65',
         safari: '>14',
+        edge: '>18',
         mobile: {
           firefox: '>68'
         }

--- a/index.js
+++ b/index.js
@@ -13,7 +13,8 @@ async function handleRequest(request) {
   })
 
   if (!supportsLazyLoadIframe) {
-    rewriter.on('iframe[loading=lazy]', new IframeHandler())
+    const iframeHandler = new IframeHandler()
+    rewriter.on('iframe[loading=lazy]', iframeHandler)
 
     const supportsLazyLoadImage = browser.satisfies({
       chrome: '>76',
@@ -31,7 +32,8 @@ async function handleRequest(request) {
     })
 
     if (!supportsLazyLoadImage) {
-      rewriter.on('img', new ImageHandler(supportsWebP))
+      const imageHandler = new ImageHandler(supportsWebP)
+      rewriter.on('img', imageHandler)
     }
   }
 

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ async function handleRequest(request) {
   const userAgent = request.headers.get('User-Agent') || ''
   const browser = Bowser.getParser(userAgent)
   const rewriter = new HTMLRewriter()
+
   const supportsLazyLoadIframe = browser.satisfies({
     chrome: '>85',
     firefox: '>82'
@@ -25,16 +26,16 @@ async function handleRequest(request) {
       }
     })
 
-    const supportsWebP = browser.satisfies({
-      chrome: '>32',
-      firefox: '>65',
-      safari: '>14',
-      mobile: {
-        firefox: '>68'
-      }
-    })
-
     if (!supportsLazyLoadImage) {
+      const supportsWebP = browser.satisfies({
+        chrome: '>32',
+        firefox: '>65',
+        safari: '>14',
+        mobile: {
+          firefox: '>68'
+        }
+      })
+
       const imageHandler = new ImageHandler(supportsWebP)
       rewriter.on('img', imageHandler)
     }

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ async function handleRequest(request) {
   const rewriter = new HTMLRewriter()
   const supportsLazyLoadIframe = browser.satisfies({
     chrome: '>85',
-    firefox: '>79'
+    firefox: '>82'
   })
 
   if (!supportsLazyLoadIframe) {

--- a/index.js
+++ b/index.js
@@ -26,9 +26,12 @@ async function handleRequest(request) {
     })
 
     const supportsWebP = browser.satisfies({
-      chrome: '>85',
-      firefox: '>79',
-      safari: '>14'
+      chrome: '>32',
+      firefox: '>65',
+      safari: '>14',
+      mobile: {
+        firefox: '>68'
+      }
     })
 
     if (!supportsLazyLoadImage) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,11 @@ account_id = "d37ab906812cbc49bfff95e41dd1f736"
 workers_dev = false
 zone_id = "b9bf055168903c1cd533603c2bf026c1"
 routes = [
-  "https://www.rankia.mx/blog/*",
-  "https://www.rankia.mx/foros/*"
+  "https://www.rankia.com/*",
+  "https://www.rankia.mx/*",
+  "https://www.rankia.pe/*",
+  "https://www.rankia.cl/*",
+  "https://www.rankia.com.ar/*",
+  "https://www.rankia.us/*",
+  "https://www.rankia.co/*"
 ]


### PR DESCRIPTION
These new handlers only patch browser that don't support lazy-load iframes, lazy-load images or WebP, but not enforce any element to be lazy because now it's handled by the application itself with https://github.com/Soluciones/rankia/pull/1516 and https://github.com/Soluciones/rankia/pull/1535.

If the browser already supports lazy-load on iframes any other check is avoided, because chronologically, lazy-load iframes has been the last feature to arrive, means that we can assume safely that WebP and lazy-load images are already supported.