### PR TITLE
Add `is=webp-support` when `loading` is not present or equal to `eager`

### DIFF
--- a/handlers/image-handler.js
+++ b/handlers/image-handler.js
@@ -5,12 +5,13 @@ class ImageHandler {
   }
 
   element (element) {
-    if (element.getAttribute('loading') === 'lazy') {
+    const loading = element.getAttribute('loading')
+    if (loading === 'lazy') {
         element.setAttribute('data-src', element.getAttribute('src'))
         element.setAttribute('is', this.customElement)
         element.removeAttribute('loading')
         element.removeAttribute('src')
-    } else if ((!element.hasAttribute('loading') || element.getAttribute('loading') === 'eager') && !element.hasAttribute('is')) {
+    } else if ((!element.hasAttribute('loading') || loading === 'eager') && !element.hasAttribute('is')) {
       if (element.getAttribute('src').endsWith('.webp') && !this.supportsWebP) {
         element.setAttribute('is', 'webp-support')
       }

--- a/handlers/image-handler.js
+++ b/handlers/image-handler.js
@@ -5,14 +5,12 @@ class ImageHandler {
   }
 
   element (element) {
-    if (element.hasAttribute('loading')) {
-      if (element.getAttribute('loading') === 'lazy') {
+    if (element.getAttribute('loading') === 'lazy') {
         element.setAttribute('data-src', element.getAttribute('src'))
         element.setAttribute('is', this.customElement)
         element.removeAttribute('loading')
         element.removeAttribute('src')
-      }
-    } else if (!element.hasAttribute('is')) {
+    } else if ((!element.hasAttribute('loading') || element.getAttribute('loading') === 'eager') && !element.hasAttribute('is')) {
       if (element.getAttribute('src').endsWith('.webp') && !this.supportsWebP) {
         element.setAttribute('is', 'webp-support')
       }

--- a/test/image-handler.js
+++ b/test/image-handler.js
@@ -59,7 +59,7 @@ describe('ImageHandler', function () {
         })
 
         context('when is using the attribute loading with `eager` value', function () {
-          it('should be preserved', function () {
+          it('keep loading=eager but also adds is=webp-support', function () {
             const image = document.createElement('image')
             image.setAttribute('loading', 'eager')
             image.setAttribute('src', 'https://www.rankia.com/images/rankia_logo.webp')
@@ -67,7 +67,7 @@ describe('ImageHandler', function () {
             imageHandler.element(image)
 
             assert.equal(image.getAttribute('loading'), 'eager')
-            assert.equal(image.hasAttribute('is'), false)
+            assert.equal(image.getAttribute('is'), 'webp-support')
             assert.equal(image.hasAttribute('src'), true)
             assert.equal(image.hasAttribute('data-src'), false)
           })


### PR DESCRIPTION
`is=webp-support` should be added when `loading` is not present or equal to `eager`


**BEFORE**
![IMG_7693](https://user-images.githubusercontent.com/1860816/92398007-0bf7da80-f128-11ea-8229-a837b386d45d.png)

**AFTER**
![Screenshot_2020-09-07-16-01-14-433_com instagram android](https://user-images.githubusercontent.com/1860816/92398032-1914c980-f128-11ea-99bf-727e925de374.jpg)

